### PR TITLE
Fixes for JSON schema validation of STAC definitions using other extensions

### DIFF
--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -5,6 +5,49 @@
   "description": "ML AOI Extension for STAC Items.",
   "oneOf": [
     {
+      "$comment": "This is the schema for STAC Collections.",
+      "allOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "Collection"
+            },
+            "summaries": {
+              "type": "object",
+              "properties": {
+                "ml-aoi:split": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/fields/properties/ml-aoi:split"
+                  }
+                }
+              }
+            },
+            "assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/fields"
+              }
+            },
+            "item_assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/fields"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        }
+      ]
+    },
+    {
+      "$comment": "This is the schema for STAC Items.",
       "allOf": [
         {
           "type": "object",
@@ -59,6 +102,33 @@
         "ml-aoi:split": {
           "type": "string",
           "enum": ["train", "test", "validate"]
+        },
+        "ml-aoi:role": {
+          "type": "string",
+          "enum": ["label", "feature"]
+        },
+        "ml-aoi:reference-grid": {
+          "type": "boolean"
+        },
+        "ml-aoi:resampling-method": {
+          "$comment": "Supported GDAL resampling method (https://gdal.org/programs/gdalwarp.html#cmdoption-gdalwarp-r)",
+          "type": "string",
+          "enum": [
+              "near",
+              "bilinear",
+              "cubic",
+              "cubcspline",
+              "lanczos",
+              "average",
+              "rms",
+              "mode",
+              "max",
+              "min",
+              "med",
+              "q1",
+              "q3",
+              "sum"
+          ]
         }
       },
       "patternProperties": {

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -63,8 +63,7 @@
       },
       "patternProperties": {
         "^(?!ml-aoi:)": {}
-      },
-      "additionalProperties": false
+      }
     }
   }
 }


### PR DESCRIPTION
## Changes

- remove `additionalProperties: false` in `fields` definition, causing it to fail JSON schema validation when the STAC Item is combined with other STAC extensions (fixes #6)
- add the definitions to allow `ml-aoi` related fields in STAC Collections (fixes #5)

## Fixes

- Fixes #5 
- Fixes #6 

## Validation 

Using this PR: https://github.com/ai-extensions/stac-data-loader/pull/2

I employ the following notebook that applies multiple STAC extensions onto the EuroSAT dataset.
At the end of the notebook, JSON schema validation is performed against every STAC Catalog, Collection and Item, for every applicable STAC Extension combination mentioned in their definition.
https://github.com/ai-extensions/stac-data-loader/blob/stac-ext-update/notebooks/stac_eurosat.ipynb

Using a remapping of 
```json
{
  "https://stac-extensions.github.io/ml-aoi/v0.1.0/schema.json": "https://raw.githubusercontent.com/crim-ca/ml-aoi/fix-schema/json-schema/schema.json"
}
```
(aka the branch of this PR)
All JSON validation succeeds.

PR https://github.com/ai-extensions/stac-data-loader/pull/2 also provides the generated samples for inspection as needed.
Under: https://github.com/ai-extensions/stac-data-loader/tree/stac-ext-update/data/EuroSAT/stac/subset

